### PR TITLE
Fix gh-pages display of fenced code blocks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+markdown: redcarpet

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,6 +4,7 @@
 <link href="{{page.root}}/css/bootstrap/bootstrap-responsive.css" rel="stylesheet" />
 <link rel="stylesheet" type="text/css" href="{{page.root}}/css/swc.css" />
 <link rel="stylesheet" type="text/css" href="{{page.root}}/css/swc-bootstrap.css" />
+<link rel="stylesheet" type="text/css" href="{{page.root}}/css/pygments/friendly.css" />
 <meta charset="UTF-8" />
 <meta http-equiv="last-modified" content="{{site.timestamp}}" />
 <!-- HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/css/pygments/friendly.css
+++ b/css/pygments/friendly.css
@@ -1,0 +1,61 @@
+.hll { background-color: #ffffcc }
+.c { color: #60a0b0; font-style: italic } /* Comment */
+.err { border: 1px solid #FF0000 } /* Error */
+.k { color: #007020; font-weight: bold } /* Keyword */
+.o { color: #666666 } /* Operator */
+.cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.cp { color: #007020 } /* Comment.Preproc */
+.c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.gd { color: #A00000 } /* Generic.Deleted */
+.ge { font-style: italic } /* Generic.Emph */
+.gr { color: #FF0000 } /* Generic.Error */
+.gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.gi { color: #00A000 } /* Generic.Inserted */
+.go { color: #888888 } /* Generic.Output */
+.gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.gs { font-weight: bold } /* Generic.Strong */
+.gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.gt { color: #0044DD } /* Generic.Traceback */
+.kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.kp { color: #007020 } /* Keyword.Pseudo */
+.kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.kt { color: #902000 } /* Keyword.Type */
+.m { color: #40a070 } /* Literal.Number */
+.s { color: #4070a0 } /* Literal.String */
+.na { color: #4070a0 } /* Name.Attribute */
+.nb { color: #007020 } /* Name.Builtin */
+.nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.no { color: #60add5 } /* Name.Constant */
+.nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.ne { color: #007020 } /* Name.Exception */
+.nf { color: #06287e } /* Name.Function */
+.nl { color: #002070; font-weight: bold } /* Name.Label */
+.nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.nt { color: #062873; font-weight: bold } /* Name.Tag */
+.nv { color: #bb60d5 } /* Name.Variable */
+.ow { color: #007020; font-weight: bold } /* Operator.Word */
+.w { color: #bbbbbb } /* Text.Whitespace */
+.mf { color: #40a070 } /* Literal.Number.Float */
+.mh { color: #40a070 } /* Literal.Number.Hex */
+.mi { color: #40a070 } /* Literal.Number.Integer */
+.mo { color: #40a070 } /* Literal.Number.Oct */
+.sb { color: #4070a0 } /* Literal.String.Backtick */
+.sc { color: #4070a0 } /* Literal.String.Char */
+.sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.s2 { color: #4070a0 } /* Literal.String.Double */
+.se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.sh { color: #4070a0 } /* Literal.String.Heredoc */
+.si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.sx { color: #c65d09 } /* Literal.String.Other */
+.sr { color: #235388 } /* Literal.String.Regex */
+.s1 { color: #4070a0 } /* Literal.String.Single */
+.ss { color: #517918 } /* Literal.String.Symbol */
+.bp { color: #007020 } /* Name.Builtin.Pseudo */
+.vc { color: #bb60d5 } /* Name.Variable.Class */
+.vg { color: #bb60d5 } /* Name.Variable.Global */
+.vi { color: #bb60d5 } /* Name.Variable.Instance */
+.il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ venue:
 address:
 country: United-States
 humandate: April 23-24, 2015
-contributors: ["Tracy Teal", "John Gossett", "Mariela Perignon"]
+contributors: ["Tracy Teal", "John Gosset", "Mariela Perignon"]
 contact: 
 raw: raw.github.com/datacarpentry/2015-04-23-stanford/gh-pages
 


### PR DESCRIPTION
GitHub's gh-pages markdown rendering can be a bit of a headache (the term "markdown hell" comes up in online discussions not infrequently...).

This PR adds some minimal configuration enabling:
- fenced code blocks to display properly 
- syntax highlighting

Compare the code blocks in [your current gh-pages](http://lwasser.github.io/python-ecology/00-short-introduction-to-Python) with [mine](http://qjcg.github.io/python-ecology/00-short-introduction-to-Python) to see the difference.
